### PR TITLE
Add basic parsing support

### DIFF
--- a/Sources/SwiftParser/CodeParser.swift
+++ b/Sources/SwiftParser/CodeParser.swift
@@ -22,6 +22,9 @@ public final class CodeParser {
         var context = CodeContext(tokens: tokens, index: 0, currentNode: rootNode, errors: [], input: input)
         while context.index < context.tokens.count {
             let token = context.tokens[context.index]
+            if token.kindDescription == "eof" {
+                break
+            }
             var matched = false
             for builder in builders {
                 if builder.accept(context: context, token: token) {

--- a/Sources/SwiftParser/CodeParser.swift
+++ b/Sources/SwiftParser/CodeParser.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public final class CodeParser {
+    private var builders: [CodeElementBuilder]
+    private let tokenizer: CodeTokenizer
+
+    public init(tokenizer: CodeTokenizer, builders: [CodeElementBuilder] = []) {
+        self.tokenizer = tokenizer
+        self.builders = builders
+    }
+
+    public func register(builder: CodeElementBuilder) {
+        builders.append(builder)
+    }
+
+    public func clearBuilders() {
+        builders.removeAll()
+    }
+
+    public func parse(_ input: String, rootNode: CodeNode) -> (node: CodeNode, context: CodeContext) {
+        let tokens = tokenizer.tokenize(input)
+        var context = CodeContext(tokens: tokens, index: 0, currentNode: rootNode, errors: [], input: input)
+        while context.index < context.tokens.count {
+            let token = context.tokens[context.index]
+            var matched = false
+            for builder in builders {
+                if builder.accept(context: context, token: token) {
+                    builder.build(context: &context)
+                    matched = true
+                    break
+                }
+            }
+            if !matched {
+                context.errors.append(CodeError("Unrecognized token \(token.kindDescription)", range: token.range))
+                context.index += 1
+            }
+        }
+        return (rootNode, context)
+    }
+
+    public func update(_ input: String, rootNode: CodeNode) -> (node: CodeNode, context: CodeContext) {
+        // Simple implementation: reparse everything
+        return parse(input, rootNode: rootNode)
+    }
+}

--- a/Sources/SwiftParser/Core.swift
+++ b/Sources/SwiftParser/Core.swift
@@ -75,4 +75,5 @@ public protocol CodeLanguage {
     var tokenizer: CodeTokenizer { get }
     var builders: [CodeElementBuilder] { get }
     var rootElement: any CodeElement { get }
+    var expressionBuilder: CodeExpressionBuilder? { get }
 }

--- a/Sources/SwiftParser/Core.swift
+++ b/Sources/SwiftParser/Core.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+public protocol CodeElement {}
+
+public protocol CodeToken {
+    var kindDescription: String { get }
+    var text: String { get }
+    var range: Range<String.Index> { get }
+}
+
+public protocol CodeTokenizer {
+    func tokenize(_ input: String) -> [any CodeToken]
+}
+
+public protocol CodeElementBuilder {
+    func accept(context: CodeContext, token: any CodeToken) -> Bool
+    func build(context: inout CodeContext)
+}
+
+public final class CodeNode {
+    public let type: any CodeElement
+    public var value: String
+    public weak var parent: CodeNode?
+    public var children: [CodeNode] = []
+    public var range: Range<String.Index>?
+
+    public var id: Int {
+        return String(describing: type).hashValue ^ value.hashValue
+    }
+
+    public init(type: any CodeElement, value: String, range: Range<String.Index>? = nil) {
+        self.type = type
+        self.value = value
+        self.range = range
+    }
+
+    public func addChild(_ node: CodeNode) {
+        node.parent = self
+        children.append(node)
+    }
+}
+
+public struct CodeError: Error {
+    public let message: String
+    public let range: Range<String.Index>?
+    public init(_ message: String, range: Range<String.Index>? = nil) {
+        self.message = message
+        self.range = range
+    }
+}
+
+public struct CodeContext {
+    public var tokens: [any CodeToken]
+    public var index: Int
+    public var currentNode: CodeNode
+    public var errors: [CodeError]
+    public let input: String
+
+    public init(tokens: [any CodeToken], index: Int, currentNode: CodeNode, errors: [CodeError], input: String) {
+        self.tokens = tokens
+        self.index = index
+        self.currentNode = currentNode
+        self.errors = errors
+        self.input = input
+    }
+}
+
+public protocol CodeLanguage {
+    var tokenizer: CodeTokenizer { get }
+    var builders: [CodeElementBuilder] { get }
+    var rootElement: any CodeElement { get }
+}

--- a/Sources/SwiftParser/Core.swift
+++ b/Sources/SwiftParser/Core.swift
@@ -25,7 +25,13 @@ public final class CodeNode {
     public var range: Range<String.Index>?
 
     public var id: Int {
-        return String(describing: type).hashValue ^ value.hashValue
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(value)
+        for child in children {
+            hasher.combine(child.id)
+        }
+        return hasher.finalize()
     }
 
     public init(type: any CodeElement, value: String, range: Range<String.Index>? = nil) {

--- a/Sources/SwiftParser/ExpressionBuilder.swift
+++ b/Sources/SwiftParser/ExpressionBuilder.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public protocol CodeExpressionBuilder: CodeElementBuilder {
+    func isPrefix(token: any CodeToken) -> Bool
+    func prefix(context: inout CodeContext, token: any CodeToken) -> CodeNode?
+    func infixBindingPower(of token: any CodeToken) -> (left: Int, right: Int)?
+    func infix(context: inout CodeContext, left: CodeNode, token: any CodeToken, right: CodeNode) -> CodeNode
+}
+
+public extension CodeExpressionBuilder {
+    func accept(context: CodeContext, token: any CodeToken) -> Bool {
+        return isPrefix(token: token)
+    }
+
+    func build(context: inout CodeContext) {
+        if let node = parse(context: &context) {
+            context.currentNode.addChild(node)
+        }
+    }
+
+    func parse(context: inout CodeContext, minBP: Int = 0) -> CodeNode? {
+        guard context.index < context.tokens.count else { return nil }
+        let first = context.tokens[context.index]
+        guard isPrefix(token: first) else { return nil }
+        context.index += 1
+        guard var left = prefix(context: &context, token: first) else { return nil }
+        while context.index < context.tokens.count {
+            let opToken = context.tokens[context.index]
+            guard let bp = infixBindingPower(of: opToken), bp.left >= minBP else { break }
+            context.index += 1
+            let right = parse(context: &context, minBP: bp.right) ?? CodeNode(type: left.type, value: "")
+            left = infix(context: &context, left: left, token: opToken, right: right)
+        }
+        return left
+    }
+}

--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -111,9 +111,14 @@ public struct MarkdownLanguage: CodeLanguage {
                         let node = CodeNode(type: Element.paragraph, value: text)
                         context.currentNode.addChild(node)
                         return
-                    case .hash, .eof:
+                    case .hash:
                         let node = CodeNode(type: Element.paragraph, value: text)
                         context.currentNode.addChild(node)
+                        return
+                    case .eof:
+                        let node = CodeNode(type: Element.paragraph, value: text)
+                        context.currentNode.addChild(node)
+                        context.index += 1
                         return
                     }
                 } else { context.index += 1 }

--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+public struct MarkdownLanguage: CodeLanguage {
+    public enum Element: String, CodeElement {
+        case root
+        case paragraph
+        case heading
+        case text
+    }
+
+    public enum Token: CodeToken {
+        case text(String, Range<String.Index>)
+        case hash(Range<String.Index>)
+        case newline(Range<String.Index>)
+        case eof(Range<String.Index>)
+
+        public var kindDescription: String {
+            switch self {
+            case .text: return "text"
+            case .hash: return "#"
+            case .newline: return "newline"
+            case .eof: return "eof"
+            }
+        }
+
+        public var text: String {
+            switch self {
+            case .text(let s, _): return s
+            case .hash: return "#"
+            case .newline: return "\n"
+            case .eof: return ""
+            }
+        }
+
+        public var range: Range<String.Index> {
+            switch self {
+            case .text(_, let r), .hash(let r), .newline(let r), .eof(let r):
+                return r
+            }
+        }
+    }
+
+    public class Tokenizer: CodeTokenizer {
+        public init() {}
+
+        public func tokenize(_ input: String) -> [any CodeToken] {
+            var tokens: [Token] = []
+            var index = input.startIndex
+            func advance() { index = input.index(after: index) }
+            func add(_ t: Token) { tokens.append(t) }
+            while index < input.endIndex {
+                let ch = input[index]
+                if ch == "#" {
+                    let start = index
+                    advance()
+                    add(.hash(start..<index))
+                } else if ch == "\n" {
+                    let start = index
+                    advance()
+                    add(.newline(start..<index))
+                } else {
+                    let start = index
+                    while index < input.endIndex && input[index] != "\n" && input[index] != "#" {
+                        advance()
+                    }
+                    let text = String(input[start..<index])
+                    add(.text(text, start..<index))
+                }
+            }
+            let r = index..<index
+            tokens.append(.eof(r))
+            return tokens
+        }
+    }
+
+    public class HeadingBuilder: CodeElementBuilder {
+        public init() {}
+        public func accept(context: CodeContext, token: any CodeToken) -> Bool {
+            guard let tok = token as? Token else { return false }
+            if case .hash = tok { return true }
+            return false
+        }
+        public func build(context: inout CodeContext) {
+            context.index += 1
+            guard context.index < context.tokens.count else { return }
+            if let textTok = context.tokens[context.index] as? Token {
+                let node = CodeNode(type: Element.heading, value: textTok.text)
+                context.currentNode.addChild(node)
+                context.index += 1
+            }
+            // consume newline if exists
+            if let nl = context.tokens[context.index] as? Token, case .newline = nl { context.index += 1 }
+        }
+    }
+
+    public class ParagraphBuilder: CodeElementBuilder {
+        public init() {}
+        public func accept(context: CodeContext, token: any CodeToken) -> Bool {
+            if token is Token { return true } else { return false }
+        }
+        public func build(context: inout CodeContext) {
+            var text = ""
+            while context.index < context.tokens.count {
+                if let tok = context.tokens[context.index] as? Token {
+                    switch tok {
+                    case .text(let t, _):
+                        text += t
+                        context.index += 1
+                    case .newline:
+                        context.index += 1
+                        let node = CodeNode(type: Element.paragraph, value: text)
+                        context.currentNode.addChild(node)
+                        return
+                    case .hash, .eof:
+                        let node = CodeNode(type: Element.paragraph, value: text)
+                        context.currentNode.addChild(node)
+                        return
+                    }
+                } else { context.index += 1 }
+            }
+        }
+    }
+
+    public var tokenizer: CodeTokenizer { Tokenizer() }
+    public var builders: [CodeElementBuilder] { [HeadingBuilder(), ParagraphBuilder()] }
+    public var rootElement: any CodeElement { Element.root }
+    public init() {}
+}

--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -128,6 +128,7 @@ public struct MarkdownLanguage: CodeLanguage {
 
     public var tokenizer: CodeTokenizer { Tokenizer() }
     public var builders: [CodeElementBuilder] { [HeadingBuilder(), ParagraphBuilder()] }
+    public var expressionBuilder: CodeExpressionBuilder? { nil }
     public var rootElement: any CodeElement { Element.root }
     public init() {}
 }

--- a/Sources/SwiftParser/Languages/PythonLanguage.swift
+++ b/Sources/SwiftParser/Languages/PythonLanguage.swift
@@ -238,6 +238,18 @@ public struct PythonLanguage: CodeLanguage {
         }
     }
 
+    public class NewlineBuilder: CodeElementBuilder {
+        public init() {}
+        public func accept(context: CodeContext, token: any CodeToken) -> Bool {
+            guard let tok = token as? Token else { return false }
+            if case .newline = tok { return true }
+            return false
+        }
+        public func build(context: inout CodeContext) {
+            context.index += 1
+        }
+    }
+
     public class FunctionBuilder: CodeElementBuilder {
         public init() {}
         public func accept(context: CodeContext, token: any CodeToken) -> Bool {
@@ -292,7 +304,7 @@ public struct PythonLanguage: CodeLanguage {
 
     public var tokenizer: CodeTokenizer { Tokenizer() }
 
-    public var builders: [CodeElementBuilder] { [FunctionBuilder(), AssignmentBuilder()] }
+    public var builders: [CodeElementBuilder] { [NewlineBuilder(), FunctionBuilder(), AssignmentBuilder()] }
 
     public var rootElement: any CodeElement { Element.root }
 

--- a/Sources/SwiftParser/Languages/PythonLanguage.swift
+++ b/Sources/SwiftParser/Languages/PythonLanguage.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+public struct PythonLanguage: CodeLanguage {
+    public enum Element: String, CodeElement {
+        case root
+        case statement
+        case identifier
+        case number
+        case string
+        case assignment
+        case function
+        case parameters
+        case body
+        case expression
+    }
+
+    public enum Token: CodeToken {
+        case identifier(String, Range<String.Index>)
+        case number(String, Range<String.Index>)
+        case string(String, Range<String.Index>)
+        case keyword(String, Range<String.Index>)
+        case equal(Range<String.Index>)
+        case colon(Range<String.Index>)
+        case comma(Range<String.Index>)
+        case plus(Range<String.Index>)
+        case minus(Range<String.Index>)
+        case star(Range<String.Index>)
+        case slash(Range<String.Index>)
+        case lparen(Range<String.Index>)
+        case rparen(Range<String.Index>)
+        case newline(Range<String.Index>)
+        case eof(Range<String.Index>)
+
+        public var kindDescription: String {
+            switch self {
+            case .identifier: return "identifier"
+            case .number: return "number"
+            case .string: return "string"
+            case .keyword(let k, _): return "keyword(\(k))"
+            case .equal: return "="
+            case .colon: return ":"
+            case .comma: return ","
+            case .plus: return "+"
+            case .minus: return "-"
+            case .star: return "*"
+            case .slash: return "/"
+            case .lparen: return "("
+            case .rparen: return ")"
+            case .newline: return "newline"
+            case .eof: return "eof"
+            }
+        }
+
+        public var text: String {
+            switch self {
+            case let .identifier(s, _), let .number(s, _), let .string(s, _), let .keyword(s, _):
+                return s
+            case .equal: return "="
+            case .colon: return ":"
+            case .comma: return ","
+            case .plus: return "+"
+            case .minus: return "-"
+            case .star: return "*"
+            case .slash: return "/"
+            case .lparen: return "("
+            case .rparen: return ")"
+            case .newline: return "\n"
+            case .eof: return ""
+            }
+        }
+
+        public var range: Range<String.Index> {
+            switch self {
+            case .identifier(_, let r), .number(_, let r), .string(_, let r), .keyword(_, let r), .equal(let r),
+                 .colon(let r), .comma(let r), .plus(let r), .minus(let r), .star(let r), .slash(let r),
+                 .lparen(let r), .rparen(let r), .newline(let r), .eof(let r):
+                return r
+            }
+        }
+    }
+
+    public class Tokenizer: CodeTokenizer {
+        public init() {}
+
+        public func tokenize(_ input: String) -> [any CodeToken] {
+            var tokens: [Token] = []
+            var index = input.startIndex
+            func advance() { index = input.index(after: index) }
+            func add(_ token: Token) { tokens.append(token) }
+
+            while index < input.endIndex {
+                let ch = input[index]
+                if ch.isWhitespace {
+                    if ch == "\n" {
+                        let start = index
+                        advance()
+                        add(.newline(start..<index))
+                    } else {
+                        advance()
+                    }
+                } else if ch.isNumber {
+                    let start = index
+                    while index < input.endIndex && input[index].isNumber {
+                        advance()
+                    }
+                    let text = String(input[start..<index])
+                    add(.number(text, start..<index))
+                } else if ch == "\"" || ch == "'" {
+                    let quote = ch
+                    let start = index
+                    advance()
+                    while index < input.endIndex && input[index] != quote {
+                        advance()
+                    }
+                    if index < input.endIndex { advance() }
+                    let text = String(input[start..<index])
+                    add(.string(text, start..<index))
+                } else if ch.isLetter || ch == "_" {
+                    let start = index
+                    while index < input.endIndex && (input[index].isLetter || input[index].isNumber || input[index] == "_") {
+                        advance()
+                    }
+                    let text = String(input[start..<index])
+                    if ["def", "return"].contains(text) {
+                        add(.keyword(text, start..<index))
+                    } else {
+                        add(.identifier(text, start..<index))
+                    }
+                } else {
+                    let start = index
+                    switch ch {
+                    case "=":
+                        advance(); add(.equal(start..<index))
+                    case ":":
+                        advance(); add(.colon(start..<index))
+                    case ",":
+                        advance(); add(.comma(start..<index))
+                    case "+":
+                        advance(); add(.plus(start..<index))
+                    case "-":
+                        advance(); add(.minus(start..<index))
+                    case "*":
+                        advance(); add(.star(start..<index))
+                    case "/":
+                        advance(); add(.slash(start..<index))
+                    case "(":
+                        advance(); add(.lparen(start..<index))
+                    case ")":
+                        advance(); add(.rparen(start..<index))
+                    default:
+                        advance()
+                    }
+                }
+            }
+            let r = index..<index
+            tokens.append(.eof(r))
+            return tokens
+        }
+    }
+
+    struct ExpressionParser {
+        private let tokens: [any CodeToken]
+        private(set) var index: Int
+
+        init(tokens: [any CodeToken], startIndex: Int) {
+            self.tokens = tokens
+            self.index = startIndex
+        }
+
+        mutating func parse(_ minBP: Int = 0) -> CodeNode? {
+            guard index < tokens.count, let first = tokens[index] as? Token else { return nil }
+            index += 1
+            var left: CodeNode?
+            switch first {
+            case .number(let text, let range):
+                left = CodeNode(type: Element.number, value: text, range: range)
+            case .identifier(let text, let range):
+                left = CodeNode(type: Element.identifier, value: text, range: range)
+            case .lparen:
+                left = parse(0)
+                if index < tokens.count, let t = tokens[index] as? Token, case .rparen = t { index += 1 }
+            default:
+                return nil
+            }
+            guard var l = left else { return nil }
+            while index < tokens.count, let op = tokens[index] as? Token, let bp = infixBindingPower(op), bp.left >= minBP {
+                index += 1
+                let rhs = parse(bp.right) ?? CodeNode(type: Element.number, value: "", range: op.range)
+                let opNode = CodeNode(type: Element.expression, value: op.text, range: op.range)
+                opNode.addChild(l)
+                opNode.addChild(rhs)
+                l = opNode
+            }
+            return l
+        }
+
+        private func infixBindingPower(_ token: Token) -> (left: Int, right: Int)? {
+            switch token {
+            case .plus, .minus:
+                return (left: 10, right: 11)
+            case .star, .slash:
+                return (left: 20, right: 21)
+            default:
+                return nil
+            }
+        }
+    }
+
+    public class AssignmentBuilder: CodeElementBuilder {
+        public init() {}
+        public func accept(context: CodeContext, token: any CodeToken) -> Bool {
+            guard context.index + 2 < context.tokens.count else { return false }
+            if let tok = context.tokens[context.index] as? Token,
+               case .identifier = tok,
+               let eq = context.tokens[context.index + 1] as? Token,
+               case .equal = eq {
+                return true
+            }
+            return false
+        }
+
+        public func build(context: inout CodeContext) {
+            guard let identifierTok = context.tokens[context.index] as? Token else { return }
+            let node = CodeNode(type: Element.assignment, value: identifierTok.text)
+            context.currentNode.addChild(node)
+            context.index += 2 // skip identifier and '='
+
+            var parser = ExpressionParser(tokens: context.tokens, startIndex: context.index)
+            if let exprNode = parser.parse() {
+                node.addChild(exprNode)
+                context.index = parser.index
+            }
+            if context.index < context.tokens.count,
+               let nl = context.tokens[context.index] as? Token,
+               case .newline = nl {
+                context.index += 1
+            }
+        }
+    }
+
+    public class FunctionBuilder: CodeElementBuilder {
+        public init() {}
+        public func accept(context: CodeContext, token: any CodeToken) -> Bool {
+            guard let tok = token as? Token else { return false }
+            if case .keyword("def", _) = tok { return true }
+            return false
+        }
+
+        public func build(context: inout CodeContext) {
+            // def name():\n
+            context.index += 1 // skip 'def'
+            guard let nameTok = context.tokens[context.index] as? Token else { return }
+            let funcNode = CodeNode(type: Element.function, value: nameTok.text)
+            context.currentNode.addChild(funcNode)
+            context.index += 1 // skip name
+            // skip params
+            if let lparen = context.tokens[context.index] as? Token, case .lparen = lparen {
+                context.index += 1
+                let paramsNode = CodeNode(type: Element.parameters, value: "")
+                funcNode.addChild(paramsNode)
+                while context.index < context.tokens.count {
+                    if let tok = context.tokens[context.index] as? Token {
+                        switch tok {
+                        case .identifier:
+                            paramsNode.addChild(CodeNode(type: Element.identifier, value: tok.text))
+                            context.index += 1
+                            if let comma = context.tokens[context.index] as? Token, case .comma = comma {
+                                context.index += 1
+                            }
+                        case .rparen:
+                            context.index += 1
+                            break
+                        default:
+                            context.index += 1
+                        }
+                        if case .rparen = tok { break }
+                    }
+                }
+            }
+            if let colon = context.tokens[context.index] as? Token, case .colon = colon {
+                context.index += 1
+            }
+            let bodyNode = CodeNode(type: Element.body, value: "")
+            funcNode.addChild(bodyNode)
+            // consume until newline or eof
+            while context.index < context.tokens.count {
+                if let tok = context.tokens[context.index] as? Token, case .newline = tok { context.index += 1; break }
+                context.index += 1
+            }
+        }
+    }
+
+    public var tokenizer: CodeTokenizer { Tokenizer() }
+
+    public var builders: [CodeElementBuilder] { [FunctionBuilder(), AssignmentBuilder()] }
+
+    public var rootElement: any CodeElement { Element.root }
+
+    public init() {}
+}

--- a/Sources/SwiftParser/SwiftParser.swift
+++ b/Sources/SwiftParser/SwiftParser.swift
@@ -3,21 +3,29 @@ import Foundation
 /// SwiftParser - A Swift parsing framework
 public struct SwiftParser {
     public init() {}
-    
-    /// Parse a Swift source code string
-    /// - Parameter source: The Swift source code to parse
-    /// - Returns: A parsed representation of the source code
+
+    public func parse(_ source: String, language: CodeLanguage) -> ParsedSource {
+        let root = CodeNode(type: language.rootElement, value: "")
+        let parser = CodeParser(tokenizer: language.tokenizer, builders: language.builders)
+        let result = parser.parse(source, rootNode: root)
+        return ParsedSource(content: source, root: result.node, errors: result.context.errors)
+    }
+
+    /// Convenience method using Python language by default
     public func parse(_ source: String) -> ParsedSource {
-        // TODO: Implement parsing logic
-        return ParsedSource(content: source)
+        return parse(source, language: PythonLanguage())
     }
 }
 
-/// Represents a parsed Swift source file
+/// Represents a parsed source file
 public struct ParsedSource {
     public let content: String
-    
-    public init(content: String) {
+    public let root: CodeNode
+    public let errors: [CodeError]
+
+    public init(content: String, root: CodeNode, errors: [CodeError] = []) {
         self.content = content
+        self.root = root
+        self.errors = errors
     }
 }

--- a/Sources/SwiftParser/SwiftParser.swift
+++ b/Sources/SwiftParser/SwiftParser.swift
@@ -6,7 +6,7 @@ public struct SwiftParser {
 
     public func parse(_ source: String, language: CodeLanguage) -> ParsedSource {
         let root = CodeNode(type: language.rootElement, value: "")
-        let parser = CodeParser(tokenizer: language.tokenizer, builders: language.builders)
+        let parser = CodeParser(tokenizer: language.tokenizer, builders: language.builders, expressionBuilder: language.expressionBuilder)
         let result = parser.parse(source, rootNode: root)
         return ParsedSource(content: source, root: result.node, errors: result.context.errors)
     }

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -2,47 +2,34 @@ import XCTest
 @testable import SwiftParser
 
 final class SwiftParserTests: XCTestCase {
-    
+
     func testParserInitialization() {
         let parser = SwiftParser()
         XCTAssertNotNil(parser)
     }
-    
-    func testBasicParsing() {
+
+    func testPythonAssignment() {
         let parser = SwiftParser()
-        let sourceCode = "let x = 42"
-        
-        let result = parser.parse(sourceCode)
-        
-        XCTAssertEqual(result.content, sourceCode)
+        let source = "x = 1"
+        let result = parser.parse(source, language: PythonLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.first?.type as? PythonLanguage.Element, PythonLanguage.Element.assignment)
     }
-    
-    func testEmptySourceParsing() {
+
+    func testMarkdownHeading() {
         let parser = SwiftParser()
-        let sourceCode = ""
-        
-        let result = parser.parse(sourceCode)
-        
-        XCTAssertEqual(result.content, sourceCode)
+        let source = "# Title\nHello"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.count, 2)
     }
-    
-    func testComplexSourceParsing() {
+
+    func testPrattExpression() {
         let parser = SwiftParser()
-        let sourceCode = """
-        import Foundation
-        
-        struct Example {
-            let name: String
-            
-            func greet() {
-                print("Hello, \\(name)!")
-            }
-        }
-        """
-        
-        let result = parser.parse(sourceCode)
-        
-        XCTAssertEqual(result.content, sourceCode)
-        XCTAssertTrue(result.content.contains("struct Example"))
+        let source = "x = 1 + 2 * 3"
+        let result = parser.parse(source, language: PythonLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let assign = result.root.children.first
+        XCTAssertEqual(assign?.children.first?.type as? PythonLanguage.Element, PythonLanguage.Element.expression)
     }
 }

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -32,4 +32,14 @@ final class SwiftParserTests: XCTestCase {
         let assign = result.root.children.first
         XCTAssertEqual(assign?.children.first?.type as? PythonLanguage.Element, PythonLanguage.Element.expression)
     }
+
+    func testStableNodeID() {
+        let n1 = CodeNode(type: PythonLanguage.Element.identifier, value: "x")
+        n1.addChild(CodeNode(type: PythonLanguage.Element.number, value: "1"))
+
+        let n2 = CodeNode(type: PythonLanguage.Element.identifier, value: "x")
+        n2.addChild(CodeNode(type: PythonLanguage.Element.number, value: "1"))
+
+        XCTAssertEqual(n1.id, n2.id)
+    }
 }


### PR DESCRIPTION
## Summary
- extend Python tokenizer with operator tokens
- implement simple Pratt parser for Python expressions
- parse expressions in assignment builder
- add unit test for Pratt parsing

## Testing
- `swift test` *(0 tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_6874b4c899088322817ce5e5ce707440