### PR TITLE
Support multiple expression builders

### DIFF
--- a/Sources/SwiftParser/Core.swift
+++ b/Sources/SwiftParser/Core.swift
@@ -75,5 +75,5 @@ public protocol CodeLanguage {
     var tokenizer: CodeTokenizer { get }
     var builders: [CodeElementBuilder] { get }
     var rootElement: any CodeElement { get }
-    var expressionBuilder: CodeExpressionBuilder? { get }
+    var expressionBuilders: [CodeExpressionBuilder] { get }
 }

--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -128,7 +128,7 @@ public struct MarkdownLanguage: CodeLanguage {
 
     public var tokenizer: CodeTokenizer { Tokenizer() }
     public var builders: [CodeElementBuilder] { [HeadingBuilder(), ParagraphBuilder()] }
-    public var expressionBuilder: CodeExpressionBuilder? { nil }
+    public var expressionBuilders: [CodeExpressionBuilder] { [] }
     public var rootElement: any CodeElement { Element.root }
     public init() {}
 }

--- a/Sources/SwiftParser/Languages/PythonLanguage.swift
+++ b/Sources/SwiftParser/Languages/PythonLanguage.swift
@@ -313,7 +313,7 @@ public struct PythonLanguage: CodeLanguage {
         return [NewlineBuilder(), FunctionBuilder(), AssignmentBuilder(expressionBuilder: expr)]
     }
 
-    public var expressionBuilder: CodeExpressionBuilder? { ExpressionBuilder() }
+    public var expressionBuilders: [CodeExpressionBuilder] { [ExpressionBuilder()] }
 
     public var rootElement: any CodeElement { Element.root }
 

--- a/Sources/SwiftParser/SwiftParser.swift
+++ b/Sources/SwiftParser/SwiftParser.swift
@@ -6,7 +6,7 @@ public struct SwiftParser {
 
     public func parse(_ source: String, language: CodeLanguage) -> ParsedSource {
         let root = CodeNode(type: language.rootElement, value: "")
-        let parser = CodeParser(tokenizer: language.tokenizer, builders: language.builders, expressionBuilder: language.expressionBuilder)
+        let parser = CodeParser(tokenizer: language.tokenizer, builders: language.builders, expressionBuilders: language.expressionBuilders)
         let result = parser.parse(source, rootNode: root)
         return ParsedSource(content: source, root: result.node, errors: result.context.errors)
     }


### PR DESCRIPTION
## Summary
- allow `CodeParser` to work with multiple expression builders
- surface expression builder arrays via `CodeLanguage`
- update built-in languages and parser initialization

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6874d7c4e42c83229612ec6121cfb9ec