### PR TITLE
Implement builder removal APIs

### DIFF
--- a/Sources/SwiftParser/CodeParser.swift
+++ b/Sources/SwiftParser/CodeParser.swift
@@ -20,12 +20,32 @@ public final class CodeParser {
         builders.append(builder)
     }
 
+    public func unregister(builder: CodeElementBuilder) {
+        if let target = builder as? AnyObject {
+            if let index = builders.firstIndex(where: { ($0 as? AnyObject) === target }) {
+                builders.remove(at: index)
+            }
+        }
+    }
+
     public func clearBuilders() {
         builders.removeAll()
     }
 
     public func register(expressionBuilder: CodeExpressionBuilder) {
         expressionBuilders.append(expressionBuilder)
+    }
+
+    public func unregister(expressionBuilder: CodeExpressionBuilder) {
+        if let target = expressionBuilder as? AnyObject {
+            if let index = expressionBuilders.firstIndex(where: { ($0 as? AnyObject) === target }) {
+                expressionBuilders.remove(at: index)
+            }
+        }
+    }
+
+    public func clearExpressionBuilders() {
+        expressionBuilders.removeAll()
     }
 
     public func parse(_ input: String, rootNode: CodeNode) -> (node: CodeNode, context: CodeContext) {

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -74,4 +74,40 @@ final class SwiftParserTests: XCTestCase {
         _ = parser.update("x = 2", rootNode: root)
         XCTAssertEqual(root.children.first?.children.first?.value, "2")
     }
+
+    func testUnregisterElementBuilder() {
+        let tokenizer = PythonLanguage.Tokenizer()
+        let expr = PythonLanguage.ExpressionBuilder()
+        let assign = PythonLanguage.AssignmentBuilder(expressionBuilder: expr)
+        let parser = CodeParser(tokenizer: tokenizer)
+        parser.register(builder: assign)
+        parser.register(expressionBuilder: expr)
+
+        let root1 = CodeNode(type: PythonLanguage.Element.root, value: "")
+        _ = parser.parse("x = 1", rootNode: root1)
+        XCTAssertEqual(root1.children.first?.type as? PythonLanguage.Element, .assignment)
+
+        parser.unregister(builder: assign)
+
+        let root2 = CodeNode(type: PythonLanguage.Element.root, value: "")
+        _ = parser.parse("x = 1", rootNode: root2)
+        XCTAssertEqual(root2.children.first?.type as? PythonLanguage.Element, .identifier)
+    }
+
+    func testUnregisterExpressionBuilder() {
+        let tokenizer = PythonLanguage.Tokenizer()
+        let expr = PythonLanguage.ExpressionBuilder()
+        let parser = CodeParser(tokenizer: tokenizer)
+        parser.register(expressionBuilder: expr)
+
+        let root1 = CodeNode(type: PythonLanguage.Element.root, value: "")
+        _ = parser.parse("1 + 2", rootNode: root1)
+        XCTAssertEqual(root1.children.count, 1)
+
+        parser.unregister(expressionBuilder: expr)
+
+        let root2 = CodeNode(type: PythonLanguage.Element.root, value: "")
+        _ = parser.parse("1 + 2", rootNode: root2)
+        XCTAssertEqual(root2.children.count, 0)
+    }
 }


### PR DESCRIPTION
## Summary
- support removing individual `CodeElementBuilder`s
- add `unregister(expressionBuilder:)` and `clearExpressionBuilders()`
- test unregistering both builder types works

## Testing
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6874e5b725b4832286feea1ac8154cf8