### PR TITLE
Extend Markdown parser features

### DIFF
--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -68,6 +68,22 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .link)
     }
 
+    func testMarkdownBlockQuote() {
+        let parser = SwiftParser()
+        let source = "> quote"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .blockQuote)
+    }
+
+    func testMarkdownImage() {
+        let parser = SwiftParser()
+        let source = "![alt](url)"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .image)
+    }
+
     func testPrattExpression() {
         let parser = SwiftParser()
         let source = "x = 1 + 2 * 3"


### PR DESCRIPTION
## Summary
- expand Markdown token set for punctuation and HTML
- add many Markdown element builders like block quotes, images, thematic breaks, etc.
- support indented code blocks, tables, autolinks and more
- test new Markdown block quote and image handling

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68753179bde08322aa8581ede9cbeaf9