### PR TITLE
Add Markdown reference link support

### DIFF
--- a/Sources/SwiftParser/CodeParser.swift
+++ b/Sources/SwiftParser/CodeParser.swift
@@ -50,7 +50,7 @@ public final class CodeParser {
 
     public func parse(_ input: String, rootNode: CodeNode) -> (node: CodeNode, context: CodeContext) {
         let tokens = tokenizer.tokenize(input)
-        var context = CodeContext(tokens: tokens, index: 0, currentNode: rootNode, errors: [], input: input)
+        var context = CodeContext(tokens: tokens, index: 0, currentNode: rootNode, errors: [], input: input, linkReferences: [:])
 
         snapshots = [:]
         lastTokens = tokens

--- a/Sources/SwiftParser/Core.swift
+++ b/Sources/SwiftParser/Core.swift
@@ -61,13 +61,15 @@ public struct CodeContext {
     public var currentNode: CodeNode
     public var errors: [CodeError]
     public let input: String
+    public var linkReferences: [String: String]
 
-    public init(tokens: [any CodeToken], index: Int, currentNode: CodeNode, errors: [CodeError], input: String) {
+    public init(tokens: [any CodeToken], index: Int, currentNode: CodeNode, errors: [CodeError], input: String, linkReferences: [String: String] = [:]) {
         self.tokens = tokens
         self.index = index
         self.currentNode = currentNode
         self.errors = errors
         self.input = input
+        self.linkReferences = linkReferences
     }
 
     /// Snapshot represents a parser state that can be restored later.
@@ -76,11 +78,12 @@ public struct CodeContext {
         fileprivate let node: CodeNode
         fileprivate let childCount: Int
         fileprivate let errorCount: Int
+        fileprivate let linkReferences: [String: String]
     }
 
     /// Capture the current parser state so it can be restored on demand.
     public func snapshot() -> Snapshot {
-        Snapshot(index: index, node: currentNode, childCount: currentNode.children.count, errorCount: errors.count)
+        Snapshot(index: index, node: currentNode, childCount: currentNode.children.count, errorCount: errors.count, linkReferences: linkReferences)
     }
 
     /// Restore the parser to a previously captured state, discarding any new nodes or errors.
@@ -93,6 +96,7 @@ public struct CodeContext {
         if errors.count > snapshot.errorCount {
             errors.removeLast(errors.count - snapshot.errorCount)
         }
+        linkReferences = snapshot.linkReferences
     }
 }
 

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -76,6 +76,14 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .link)
     }
 
+    func testMarkdownReferenceLink() {
+        let parser = SwiftParser()
+        let source = "[title][ref]\n[ref]: http://example.com"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .link)
+    }
+
     func testMarkdownBlockQuote() {
         let parser = SwiftParser()
         let source = "> quote"


### PR DESCRIPTION
## Summary
- extend `CodeContext` to store link references
- add builder for reference definitions
- expand link builder to resolve reference links
- wire new builder into Markdown language
- test reference link parsing

## Testing
- `swift test` *(fails: `swift: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68753dd6830c8322a12d9f31ab19f6b1