### PR TITLE
Support bare automatic links

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -710,6 +710,44 @@ public struct MarkdownLanguage: CodeLanguage {
         }
     }
 
+    public class BareAutoLinkBuilder: CodeElementBuilder {
+        private static let regex: NSRegularExpression = {
+            let pattern = #"^((https?|ftp)://[^\s<>]+|www\.[^\s<>]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})"#
+            return try! NSRegularExpression(pattern: pattern, options: [])
+        }()
+
+        public init() {}
+
+        public func accept(context: CodeContext, token: any CodeToken) -> Bool {
+            guard let tok = token as? Token else { return false }
+            let start = tok.range.lowerBound
+            let text = String(context.input[start...])
+            let range = NSRange(location: 0, length: text.utf16.count)
+            if let m = Self.regex.firstMatch(in: text, range: range), m.range.location == 0 {
+                return true
+            }
+            return false
+        }
+
+        public func build(context: inout CodeContext) {
+            guard let tok = context.tokens[context.index] as? Token else { return }
+            let start = tok.range.lowerBound
+            let text = String(context.input[start...])
+            let range = NSRange(location: 0, length: text.utf16.count)
+            guard let m = Self.regex.firstMatch(in: text, range: range) else { return }
+            let endPos = context.input.index(start, offsetBy: m.range.length)
+            let url = String(context.input[start..<endPos])
+            context.currentNode.addChild(CodeNode(type: Element.autoLink, value: url))
+            while context.index < context.tokens.count {
+                if let t = context.tokens[context.index] as? Token, t.range.upperBound <= endPos {
+                    context.index += 1
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
     public class TableBuilder: CodeElementBuilder {
         public init() {}
         public func accept(context: CodeContext, token: any CodeToken) -> Bool {
@@ -1016,7 +1054,7 @@ public struct MarkdownLanguage: CodeLanguage {
 
     public var tokenizer: CodeTokenizer { Tokenizer() }
     public var builders: [CodeElementBuilder] {
-        [HeadingBuilder(), SetextHeadingBuilder(), CodeBlockBuilder(), IndentedCodeBlockBuilder(), BlockQuoteBuilder(), ThematicBreakBuilder(), OrderedListItemBuilder(), ListItemBuilder(), ImageBuilder(), HTMLBuilder(), EntityBuilder(), StrikethroughBuilder(), AutoLinkBuilder(), TableBuilder(), FootnoteBuilder(), LinkReferenceDefinitionBuilder(), LinkBuilder(), StrongBuilder(), EmphasisBuilder(), InlineCodeBuilder(), ParagraphBuilder()]
+        [HeadingBuilder(), SetextHeadingBuilder(), CodeBlockBuilder(), IndentedCodeBlockBuilder(), BlockQuoteBuilder(), ThematicBreakBuilder(), OrderedListItemBuilder(), ListItemBuilder(), ImageBuilder(), HTMLBuilder(), EntityBuilder(), StrikethroughBuilder(), AutoLinkBuilder(), BareAutoLinkBuilder(), TableBuilder(), FootnoteBuilder(), LinkReferenceDefinitionBuilder(), LinkBuilder(), StrongBuilder(), EmphasisBuilder(), InlineCodeBuilder(), ParagraphBuilder()]
     }
     public var expressionBuilders: [CodeExpressionBuilder] { [] }
     public var rootElement: any CodeElement { Element.root }

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -76,6 +76,15 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .link)
     }
 
+    func testMarkdownAutoLinkWithoutBrackets() {
+        let parser = SwiftParser()
+        let source = "https://example.com"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .autoLink)
+        XCTAssertEqual(result.root.children.first?.value, "https://example.com")
+    }
+
     func testMarkdownReferenceLink() {
         let parser = SwiftParser()
         let source = "[title][ref]\n[ref]: http://example.com"


### PR DESCRIPTION
## Summary
- add a `BareAutoLinkBuilder` to detect URLs/emails without angle brackets
- register the new builder in `MarkdownLanguage`
- test bare automatic link parsing

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6875414234b883229fc243558d36b41d