### PR TITLE
Add hard line break support

### DIFF
--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -158,6 +158,26 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(result.root.children.first?.value, "*not italic*")
     }
 
+    func testMarkdownHardBreakWithSpaces() {
+        let parser = SwiftParser()
+        let source = "line1  \nline2"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.count, 1)
+        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .paragraph)
+        XCTAssertEqual(result.root.children.first?.value, "line1\nline2")
+    }
+
+    func testMarkdownHardBreakWithBackslash() {
+        let parser = SwiftParser()
+        let source = "line1\\\nline2"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.count, 1)
+        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .paragraph)
+        XCTAssertEqual(result.root.children.first?.value, "line1\nline2")
+    }
+
     func testMarkdownEntityDecoding() {
         let parser = SwiftParser()
         let source = "&amp;&#35;&#x41;"


### PR DESCRIPTION
## Summary
- differentiate `hardBreak` tokens in the Markdown tokenizer
- trim trailing spaces for two-space line breaks
- treat hard breaks inside paragraphs as newline characters
- test for hard line break behavior

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_68754baed5e883228289c6f706f5ba55