### PR TITLE
Add structured link data in Markdown nodes

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownNodes.swift
+++ b/Sources/SwiftParser/Languages/MarkdownNodes.swift
@@ -100,8 +100,22 @@ public final class MarkdownInlineCodeNode: CodeNode {
 }
 
 public final class MarkdownLinkNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.link, value: value, range: range)
+    public let text: [CodeNode]
+    public let url: String
+
+    public init(text: [CodeNode], url: String, range: Range<String.Index>? = nil) {
+        self.text = text
+        self.url = url
+        super.init(type: MarkdownLanguage.Element.link, value: "", range: range)
+        text.forEach { addChild($0) }
+    }
+
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(url)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
     }
 }
 
@@ -118,8 +132,22 @@ public final class MarkdownThematicBreakNode: CodeNode {
 }
 
 public final class MarkdownImageNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.image, value: value, range: range)
+    public let alt: String
+    public let url: String
+
+    public init(alt: String, url: String, range: Range<String.Index>? = nil) {
+        self.alt = alt
+        self.url = url
+        super.init(type: MarkdownLanguage.Element.image, value: "", range: range)
+    }
+
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(alt)
+        hasher.combine(url)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
     }
 }
 
@@ -148,8 +176,19 @@ public final class MarkdownTableNode: CodeNode {
 }
 
 public final class MarkdownAutoLinkNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.autoLink, value: value, range: range)
+    public let url: String
+
+    public init(url: String, range: Range<String.Index>? = nil) {
+        self.url = url
+        super.init(type: MarkdownLanguage.Element.autoLink, value: url, range: range)
+    }
+
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(url)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
     }
 }
 

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -156,6 +156,9 @@ final class SwiftParserTests: XCTestCase {
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .link)
+        let link = result.root.children.first as? MarkdownLinkNode
+        XCTAssertEqual(link?.url, "url")
+        XCTAssertEqual((link?.text.first as? MarkdownTextNode)?.value, "title")
     }
 
     func testMarkdownAutoLinkWithoutBrackets() {
@@ -164,7 +167,8 @@ final class SwiftParserTests: XCTestCase {
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .autoLink)
-        XCTAssertEqual(result.root.children.first?.value, "https://example.com")
+        let auto = result.root.children.first as? MarkdownAutoLinkNode
+        XCTAssertEqual(auto?.url, "https://example.com")
     }
 
     func testMarkdownReferenceLink() {
@@ -189,6 +193,9 @@ final class SwiftParserTests: XCTestCase {
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .image)
+        let image = result.root.children.first as? MarkdownImageNode
+        XCTAssertEqual(image?.alt, "alt")
+        XCTAssertEqual(image?.url, "url")
     }
 
     func testMarkdownEscapedCharacters() {


### PR DESCRIPTION
## Summary
- add `alt`/`url` properties to `MarkdownImageNode`
- add `text`/`url` properties to `MarkdownLinkNode`
- add `url` property to `MarkdownAutoLinkNode`
- update `ImageBuilder`, `LinkBuilder`, `AutoLinkBuilder` and `BareAutoLinkBuilder`
- update tests to check the new fields

## Testing
- `swift test` *(fails: Another instance of SwiftPM is already running using '/workspace/swift-parser/.build', waiting until that process has finished execution...)*

------
https://chatgpt.com/codex/tasks/task_e_687608d644688322b561eae057932e01