### PR TITLE
Fix Setext heading loop termination

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -376,7 +376,10 @@ public struct MarkdownLanguage: CodeLanguage {
                 default:
                     return false
                 }
-                if idx < context.tokens.count, let next = context.tokens[idx] as? Token, case .newline = next { break }
+                if idx < context.tokens.count, let next = context.tokens[idx] as? Token {
+                    if case .newline = next { break }
+                    if case .eof = next { break }
+                }
             }
             if count == 0 { return false }
             if idx < context.tokens.count, let endTok = context.tokens[idx] as? Token {


### PR DESCRIPTION
## Summary
- fix potential infinite loop in `SetextHeadingBuilder.accept`

## Testing
- `swift test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68761fedb9548322aeab26beb4528c03