### PR TITLE
Add structured CodeBlockNode

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownNodes.swift
+++ b/Sources/SwiftParser/Languages/MarkdownNodes.swift
@@ -88,8 +88,16 @@ public final class MarkdownStrongNode: CodeNode {
 }
 
 public final class MarkdownCodeBlockNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.codeBlock, value: value, range: range)
+    public let lang: String?
+
+    public var content: String {
+        get { value }
+        set { value = newValue }
+    }
+
+    public init(lang: String? = nil, content: String = "", range: Range<String.Index>? = nil) {
+        self.lang = lang
+        super.init(type: MarkdownLanguage.Element.codeBlock, value: content, range: range)
     }
 }
 

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -126,7 +126,10 @@ final class SwiftParserTests: XCTestCase {
         let source = "```\ncode\n```\ninline `code`"
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
-        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .codeBlock)
+        let block = result.root.children.first as? MarkdownCodeBlockNode
+        XCTAssertEqual(block?.type as? MarkdownLanguage.Element, .codeBlock)
+        XCTAssertNil(block?.lang)
+        XCTAssertEqual(block?.content, "code\n")
         let para = result.root.children.last
         XCTAssertEqual(para?.type as? MarkdownLanguage.Element, .paragraph)
         XCTAssertEqual(para?.children.last?.type as? MarkdownLanguage.Element, .inlineCode)
@@ -138,7 +141,10 @@ final class SwiftParserTests: XCTestCase {
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
         XCTAssertEqual(result.root.children.count, 1)
-        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .codeBlock)
+        let block = result.root.children.first as? MarkdownCodeBlockNode
+        XCTAssertEqual(block?.type as? MarkdownLanguage.Element, .codeBlock)
+        XCTAssertEqual(block?.lang, "swift")
+        XCTAssertEqual(block?.content, "print(\"hi\")\n")
     }
 
     func testMarkdownTildeCodeBlock() {
@@ -147,7 +153,21 @@ final class SwiftParserTests: XCTestCase {
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
         XCTAssertEqual(result.root.children.count, 1)
-        XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .codeBlock)
+        let block = result.root.children.first as? MarkdownCodeBlockNode
+        XCTAssertEqual(block?.type as? MarkdownLanguage.Element, .codeBlock)
+        XCTAssertNil(block?.lang)
+        XCTAssertEqual(block?.content, "print(\"hi\")\n")
+    }
+
+    func testMarkdownMultiLineFencedCodeBlock() {
+        let parser = SwiftParser()
+        let source = "```swift\nprint(\"hi\")\nprint(\"bye\")\n```"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.count, 1)
+        let block = result.root.children.first as? MarkdownCodeBlockNode
+        XCTAssertEqual(block?.lang, "swift")
+        XCTAssertEqual(block?.content, "print(\"hi\")\nprint(\"bye\")\n")
     }
 
     func testMarkdownLink() {


### PR DESCRIPTION
## Summary
- extend MarkdownCodeBlockNode with `lang` and `content`
- parse language info in fenced code blocks
- update indented code blocks builder
- update unit tests for structured code blocks
- trim whitespace in fenced code block info parsing
- add test for multi-line fenced code blocks

## Testing
- `swift test -c release` *(fails: `bash: swift: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68762e365d088322b4d99452246e3cae