### PR TITLE
Add FormulaNode and Markdown formula parsing

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownNodes.swift
+++ b/Sources/SwiftParser/Languages/MarkdownNodes.swift
@@ -286,3 +286,9 @@ public final class MarkdownFootnoteReferenceNode: CodeNode {
         return hasher.finalize()
     }
 }
+
+public final class MarkdownFormulaNode: CodeNode {
+    public init(value: String = "", range: Range<String.Index>? = nil) {
+        super.init(type: MarkdownLanguage.Element.formula, value: value, range: range)
+    }
+}

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -544,4 +544,43 @@ tilde
             XCTAssertTrue(elements.contains(e), "Missing \(e)")
         }
     }
+
+    func testMarkdownInlineFormula() {
+        let parser = SwiftParser()
+        let source = "Inline \\(a+b\\) text"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let para = result.root.children.first
+        XCTAssertEqual(para?.children.count, 3)
+        let formula = para?.children[1] as? MarkdownFormulaNode
+        XCTAssertEqual(formula?.value, "a+b")
+    }
+
+    func testMarkdownDollarFormula() {
+        let parser = SwiftParser()
+        let source = "Equation $x+y$ here"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let para = result.root.children.first
+        let formula = para?.children[1] as? MarkdownFormulaNode
+        XCTAssertEqual(formula?.value, "x+y")
+    }
+
+    func testMarkdownBracketFormula() {
+        let parser = SwiftParser()
+        let source = "\\[x+y\\]"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let formula = result.root.children.first?.children.first as? MarkdownFormulaNode
+        XCTAssertEqual(formula?.value, "x+y")
+    }
+
+    func testMarkdownMultiLineFormula() {
+        let parser = SwiftParser()
+        let source = "$$x\\ny$$"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let formula = result.root.children.first?.children.first as? MarkdownFormulaNode
+        XCTAssertEqual(formula?.value, "x\\ny")
+    }
 }


### PR DESCRIPTION
## Summary
- add `FormulaNode` AST type for Markdown formulas
- extend tokenizer with formula-related tokens
- parse inline and block TeX formulas via new builders
- support `$`, `$$`, `\(`, `\)`, `\[`, `\]` syntax
- add Markdown formula tests

## Testing
- `swift test` *(failed: Another instance of SwiftPM is already running)*

------
https://chatgpt.com/codex/tasks/task_e_68767663b6bc83229199a4d9f7a42b78