### PR TITLE
Add formula block parsing with error handling

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownNodes.swift
+++ b/Sources/SwiftParser/Languages/MarkdownNodes.swift
@@ -286,3 +286,9 @@ public final class MarkdownFootnoteReferenceNode: CodeNode {
         return hasher.finalize()
     }
 }
+
+public final class MarkdownFormulaBlockNode: CodeNode {
+    public init(value: String = "", range: Range<String.Index>? = nil) {
+        super.init(type: MarkdownLanguage.Element.formulaBlock, value: value, range: range)
+    }
+}

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -544,4 +544,21 @@ tilde
             XCTAssertTrue(elements.contains(e), "Missing \(e)")
         }
     }
+
+    func testInvalidBlockFormulaStart() {
+        let parser = SwiftParser()
+        let source = "$ invalid"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertGreaterThan(result.root.children.count, 0)
+    }
+
+    func testFormulaBlockParsing() {
+        let parser = SwiftParser()
+        let source = "$$\nE=mc^2\n$$"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.count, 1)
+        let block = result.root.children.first as? MarkdownFormulaBlockNode
+        XCTAssertEqual(block?.value, "\nE=mc^2\n")
+    }
 }


### PR DESCRIPTION
## Summary
- support new tokens for LaTeX block formulas
- implement `FormulaBlockBuilder` to parse formula blocks and handle errors
- ensure paragraph builder stops at formula starts
- add `MarkdownFormulaBlockNode`
- test parsing invalid block formula start
- **new:** add a test verifying formula block parsing succeeds

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687723af10008322815c6a4844654d7e