### PR TITLE
Add Markdown inline parsing features

### DIFF
--- a/Sources/SwiftParser/Markdown/Builders/MarkdownHeadingBuilder.swift
+++ b/Sources/SwiftParser/Markdown/Builders/MarkdownHeadingBuilder.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public class MarkdownHeadingBuilder: CodeNodeBuilder {
+    public init() {}
+
+    public func build(from context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? MarkdownToken,
+              token.element == .hash,
+              isStartOfLine(context)
+        else { return false }
+
+        var level = 0
+        var idx = context.consuming
+        while idx < context.tokens.count,
+              let t = context.tokens[idx] as? MarkdownToken,
+              t.element == .hash,
+              level < 6 {
+            level += 1
+            idx += 1
+        }
+        guard idx < context.tokens.count,
+              let space = context.tokens[idx] as? MarkdownToken,
+              space.element == .space else { return false }
+        idx += 1
+
+        context.consuming = idx
+        var children = MarkdownInlineParser.parseInline(&context, stopAt: [.newline])
+        let node = HeaderNode(level: level)
+        for child in children { node.append(child) }
+        context.current.append(node)
+
+        if context.consuming < context.tokens.count,
+           let nl = context.tokens[context.consuming] as? MarkdownToken,
+           nl.element == .newline {
+            context.consuming += 1
+        }
+        return true
+    }
+
+    private func isStartOfLine(_ context: CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {
+        if context.consuming == 0 { return true }
+        if let prev = context.tokens[context.consuming - 1] as? MarkdownToken {
+            return prev.element == .newline
+        }
+        return false
+    }
+}

--- a/Sources/SwiftParser/Markdown/Builders/MarkdownInlineParser.swift
+++ b/Sources/SwiftParser/Markdown/Builders/MarkdownInlineParser.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+struct MarkdownInlineParser {
+    static func parseInline(_ context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>, stopAt: Set<MarkdownTokenElement> = [.newline, .eof]) -> [MarkdownNodeBase] {
+        var nodes: [MarkdownNodeBase] = []
+        while context.consuming < context.tokens.count {
+            guard let token = context.tokens[context.consuming] as? MarkdownToken else { break }
+            if stopAt.contains(token.element) { break }
+
+            if let emphasis = parseEmphasis(&context) {
+                nodes.append(emphasis)
+                continue
+            }
+            if token.element == .inlineCode {
+                nodes.append(InlineCodeNode(code: trimBackticks(token.text)))
+                context.consuming += 1
+                continue
+            }
+            if token.element == .htmlTag || token.element == .htmlBlock || token.element == .htmlUnclosedBlock || token.element == .htmlEntity {
+                nodes.append(HTMLNode(content: token.text))
+                context.consuming += 1
+                continue
+            }
+            if token.element == .exclamation {
+                if let image = parseImage(&context) {
+                    nodes.append(image)
+                    continue
+                }
+            }
+            if token.element == .leftBracket {
+                if let link = parseLinkOrFootnote(&context) {
+                    nodes.append(link)
+                    continue
+                }
+            }
+
+            // Default text handling
+            nodes.append(TextNode(content: token.text))
+            context.consuming += 1
+        }
+        return nodes
+    }
+
+    private static func parseEmphasis(_ context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> MarkdownNodeBase? {
+        guard context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? MarkdownToken,
+              token.element == .asterisk || token.element == .underscore else { return nil }
+        let delim = token.element
+        var count = 1
+        if context.consuming + 1 < context.tokens.count,
+           let next = context.tokens[context.consuming + 1] as? MarkdownToken,
+           next.element == delim {
+            count = 2
+        }
+        let startIndex = context.consuming
+        context.consuming += count
+        let children = parseInline(&context, stopAt: [delim])
+        var closeCount = 0
+        while closeCount < count,
+              context.consuming < context.tokens.count,
+              let close = context.tokens[context.consuming] as? MarkdownToken,
+              close.element == delim {
+            closeCount += 1
+            context.consuming += 1
+        }
+        guard closeCount == count else {
+            context.consuming = startIndex
+            return nil
+        }
+        let node: MarkdownNodeBase = (count == 2) ? StrongNode(content: "") : EmphasisNode(content: "")
+        for child in children { node.append(child) }
+        return node
+    }
+
+    private static func parseLinkOrFootnote(_ context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> MarkdownNodeBase? {
+        let start = context.consuming
+        context.consuming += 1
+        // Footnote reference [^id]
+        if context.consuming < context.tokens.count,
+           let caret = context.tokens[context.consuming] as? MarkdownToken,
+           caret.element == .caret {
+            context.consuming += 1
+            var ident = ""
+            while context.consuming < context.tokens.count,
+                  let t = context.tokens[context.consuming] as? MarkdownToken,
+                  t.element != .rightBracket {
+                ident += t.text
+                context.consuming += 1
+            }
+            guard context.consuming < context.tokens.count,
+                  let rb = context.tokens[context.consuming] as? MarkdownToken,
+                  rb.element == .rightBracket else { context.consuming = start; return nil }
+            context.consuming += 1
+            return FootnoteNode(identifier: ident, content: "", referenceText: nil, range: rb.range)
+        }
+
+        let textNodes = parseInline(&context, stopAt: [.rightBracket])
+        guard context.consuming < context.tokens.count,
+              let rb = context.tokens[context.consuming] as? MarkdownToken,
+              rb.element == .rightBracket else { context.consuming = start; return nil }
+        context.consuming += 1
+
+        // Inline link [text](url)
+        if context.consuming < context.tokens.count,
+           let lp = context.tokens[context.consuming] as? MarkdownToken,
+           lp.element == .leftParen {
+            context.consuming += 1
+            var url = ""
+            while context.consuming < context.tokens.count,
+                  let t = context.tokens[context.consuming] as? MarkdownToken,
+                  t.element != .rightParen {
+                url += t.text
+                context.consuming += 1
+            }
+            guard context.consuming < context.tokens.count,
+                  let rp = context.tokens[context.consuming] as? MarkdownToken,
+                  rp.element == .rightParen else { context.consuming = start; return nil }
+            context.consuming += 1
+            let link = LinkNode(url: url, title: "")
+            for child in textNodes { link.append(child) }
+            return link
+        }
+
+        // Reference link [text][id]
+        if context.consuming < context.tokens.count,
+           let lb = context.tokens[context.consuming] as? MarkdownToken,
+           lb.element == .leftBracket {
+            context.consuming += 1
+            var id = ""
+            while context.consuming < context.tokens.count,
+                  let t = context.tokens[context.consuming] as? MarkdownToken,
+                  t.element != .rightBracket {
+                id += t.text
+                context.consuming += 1
+            }
+            guard context.consuming < context.tokens.count,
+                  let rb2 = context.tokens[context.consuming] as? MarkdownToken,
+                  rb2.element == .rightBracket else { context.consuming = start; return nil }
+            context.consuming += 1
+            let ref = ReferenceNode(identifier: id, url: "", title: "")
+            for child in textNodes { ref.append(child) }
+            return ref
+        }
+
+        context.consuming = start
+        return nil
+    }
+
+    private static func parseImage(_ context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> MarkdownNodeBase? {
+        guard context.consuming + 1 < context.tokens.count,
+              let lb = context.tokens[context.consuming + 1] as? MarkdownToken,
+              lb.element == .leftBracket else { return nil }
+        context.consuming += 2
+        let altNodes = parseInline(&context, stopAt: [.rightBracket])
+        guard context.consuming < context.tokens.count,
+              let rb = context.tokens[context.consuming] as? MarkdownToken,
+              rb.element == .rightBracket else { context.consuming -= 2; return nil }
+        context.consuming += 1
+        guard context.consuming < context.tokens.count,
+              let lp = context.tokens[context.consuming] as? MarkdownToken,
+              lp.element == .leftParen else { context.consuming -= 3; return nil }
+        context.consuming += 1
+        var url = ""
+        while context.consuming < context.tokens.count,
+              let t = context.tokens[context.consuming] as? MarkdownToken,
+              t.element != .rightParen {
+            url += t.text
+            context.consuming += 1
+        }
+        guard context.consuming < context.tokens.count,
+              let rp = context.tokens[context.consuming] as? MarkdownToken,
+              rp.element == .rightParen else { context.consuming -= 4; return nil }
+        context.consuming += 1
+        let alt = altNodes.compactMap { ($0 as? TextNode)?.content }.joined()
+        return ImageNode(url: url, alt: alt)
+    }
+
+    private static func trimBackticks(_ text: String) -> String {
+        var t = text
+        while t.hasPrefix("`") { t.removeFirst() }
+        while t.hasSuffix("`") { t.removeLast() }
+        return t
+    }
+}

--- a/Sources/SwiftParser/Markdown/Builders/MarkdownNewlineBuilder.swift
+++ b/Sources/SwiftParser/Markdown/Builders/MarkdownNewlineBuilder.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public class MarkdownNewlineBuilder: CodeNodeBuilder {
+    public init() {}
+
+    public func build(from context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? MarkdownToken,
+              token.element == .newline else { return false }
+        context.consuming += 1
+        context.current = context.current.parent ?? context.current
+        return true
+    }
+}

--- a/Sources/SwiftParser/Markdown/Builders/MarkdownParagraphBuilder.swift
+++ b/Sources/SwiftParser/Markdown/Builders/MarkdownParagraphBuilder.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public class MarkdownParagraphBuilder: CodeNodeBuilder {
+    public init() {}
+
+    public func build(from context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? MarkdownToken,
+              token.element != .newline else { return false }
+
+        let node = ParagraphNode(range: token.range)
+        let children = MarkdownInlineParser.parseInline(&context, stopAt: [.newline])
+        for child in children { node.append(child) }
+        context.current.append(node)
+
+        if context.consuming < context.tokens.count,
+           let nl = context.tokens[context.consuming] as? MarkdownToken,
+           nl.element == .newline {
+            context.consuming += 1
+        }
+        return true
+    }
+}

--- a/Sources/SwiftParser/Markdown/Builders/MarkdownReferenceDefinitionBuilder.swift
+++ b/Sources/SwiftParser/Markdown/Builders/MarkdownReferenceDefinitionBuilder.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public class MarkdownReferenceDefinitionBuilder: CodeNodeBuilder {
+    public init() {}
+
+    public func build(from context: inout CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.tokens.count,
+              isStartOfLine(context),
+              let lb = context.tokens[context.consuming] as? MarkdownToken,
+              lb.element == .leftBracket else { return false }
+        var idx = context.consuming + 1
+        var isFootnote = false
+        if idx < context.tokens.count,
+           let caret = context.tokens[idx] as? MarkdownToken,
+           caret.element == .caret {
+            isFootnote = true
+            idx += 1
+        }
+        var identifier = ""
+        while idx < context.tokens.count,
+              let t = context.tokens[idx] as? MarkdownToken,
+              t.element != .rightBracket {
+            identifier += t.text
+            idx += 1
+        }
+        guard idx < context.tokens.count,
+              let rb = context.tokens[idx] as? MarkdownToken,
+              rb.element == .rightBracket else { return false }
+        idx += 1
+        guard idx < context.tokens.count,
+              let colon = context.tokens[idx] as? MarkdownToken,
+              colon.element == .colon else { return false }
+        idx += 1
+        // skip spaces
+        while idx < context.tokens.count,
+              let sp = context.tokens[idx] as? MarkdownToken,
+              sp.element == .space {
+            idx += 1
+        }
+        var value = ""
+        while idx < context.tokens.count,
+              let t = context.tokens[idx] as? MarkdownToken,
+              t.element != .newline {
+            value += t.text
+            idx += 1
+        }
+        context.consuming = idx
+        if idx < context.tokens.count,
+           let nl = context.tokens[idx] as? MarkdownToken,
+           nl.element == .newline {
+            context.consuming += 1
+        }
+        if isFootnote {
+            let node = FootnoteNode(identifier: identifier, content: value, referenceText: nil, range: lb.range)
+            context.current.append(node)
+        } else {
+            let node = ReferenceNode(identifier: identifier, url: value, title: "")
+            context.current.append(node)
+        }
+        return true
+    }
+
+    private func isStartOfLine(_ context: CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {
+        if context.consuming == 0 { return true }
+        if let prev = context.tokens[context.consuming - 1] as? MarkdownToken {
+            return prev.element == .newline
+        }
+        return false
+    }
+}

--- a/Sources/SwiftParser/Markdown/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Markdown/MarkdownLanguage.swift
@@ -12,7 +12,12 @@ public class MarkdownLanguage: CodeLanguage {
     // MARK: - Initialization
     public init(
         tokenizer: any CodeTokenizer<MarkdownTokenElement> = MarkdownTokenizer(),
-        consumers: [any CodeNodeBuilder<MarkdownNodeElement, MarkdownTokenElement>] = []
+        consumers: [any CodeNodeBuilder<MarkdownNodeElement, MarkdownTokenElement>] = [
+            MarkdownReferenceDefinitionBuilder(),
+            MarkdownHeadingBuilder(),
+            MarkdownParagraphBuilder(),
+            MarkdownNewlineBuilder()
+        ]
     ) {
         self.tokenizer = tokenizer
         self.builders = consumers

--- a/Tests/SwiftParserTests/Markdown/Consumer/MarkdownReferenceFootnoteTests.swift
+++ b/Tests/SwiftParserTests/Markdown/Consumer/MarkdownReferenceFootnoteTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import SwiftParser
+
+final class MarkdownReferenceFootnoteTests: XCTestCase {
+    private var parser: CodeParser<MarkdownNodeElement, MarkdownTokenElement>!
+    private var language: MarkdownLanguage!
+
+    override func setUp() {
+        super.setUp()
+        language = MarkdownLanguage()
+        parser = CodeParser(language: language)
+    }
+
+    func testReferenceDefinition() {
+        let input = "[ref]: https://example.com"
+        let root = language.root(of: input)
+        let (node, ctx) = parser.parse(input, root: root)
+        XCTAssertTrue(ctx.errors.isEmpty)
+        XCTAssertEqual(node.children.count, 1)
+        if let ref = node.children.first as? ReferenceNode {
+            XCTAssertEqual(ref.identifier, "ref")
+            XCTAssertEqual(ref.url, "https://example.com")
+        } else {
+            XCTFail("Expected ReferenceNode")
+        }
+    }
+
+    func testFootnoteDefinitionAndReference() {
+        let input = "[^1]: Footnote text\nParagraph with reference[^1]"
+        let root = language.root(of: input)
+        let (node, ctx) = parser.parse(input, root: root)
+        XCTAssertTrue(ctx.errors.isEmpty)
+        XCTAssertEqual(node.children.count, 2)
+        guard let footnote = node.children.first as? FootnoteNode else {
+            return XCTFail("Expected FootnoteNode")
+        }
+        XCTAssertEqual(footnote.identifier, "1")
+        XCTAssertEqual(footnote.content, "Footnote text")
+        guard let paragraph = node.children.last as? ParagraphNode else {
+            return XCTFail("Expected ParagraphNode")
+        }
+        XCTAssertTrue(paragraph.children.contains { $0 is FootnoteNode })
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic builders for Markdown parsing
- add heading, paragraph, newline, reference and footnote logic
- add inline parser to handle emphasis, links, images and inline HTML
- integrate builders in `MarkdownLanguage`
- add tests for reference and footnote parsing

## Testing
- `swift build`
- `swift test` *(fails: Exited with signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_687d208e808c8322840c20dda28483dd