### PR TITLE
Improve fenced code block language detection

### DIFF
--- a/Sources/SwiftParser/Markdown/Builders/MarkdownFencedCodeBuilder.swift
+++ b/Sources/SwiftParser/Markdown/Builders/MarkdownFencedCodeBuilder.swift
@@ -10,7 +10,8 @@ public class MarkdownFencedCodeBuilder: CodeNodeBuilder {
               isStartOfLine(context) else { return false }
         context.consuming += 1
         let code = trimFence(token.text)
-        let node = CodeBlockNode(source: code, language: nil)
+        let language = extractLanguage(token.text)
+        let node = CodeBlockNode(source: code, language: language)
         context.current.append(node)
         if context.consuming < context.tokens.count,
            let nl = context.tokens[context.consuming] as? MarkdownToken,
@@ -28,6 +29,18 @@ public class MarkdownFencedCodeBuilder: CodeNodeBuilder {
             lines.removeLast()
         }
         return lines.joined(separator: "\n")
+    }
+
+    private func extractLanguage(_ text: String) -> String? {
+        guard let firstLine = text.split(separator: "\n", maxSplits: 1).first else {
+            return nil
+        }
+        var cleaned = firstLine.trimmingCharacters(in: .whitespaces)
+        while cleaned.starts(with: "`") {
+            cleaned.removeFirst()
+        }
+        let lang = cleaned.trimmingCharacters(in: .whitespaces)
+        return lang.isEmpty ? nil : lang
     }
 
     private func isStartOfLine(_ context: CodeContext<MarkdownNodeElement, MarkdownTokenElement>) -> Bool {

--- a/Tests/SwiftParserTests/Markdown/Consumer/MarkdownBlockElementTests.swift
+++ b/Tests/SwiftParserTests/Markdown/Consumer/MarkdownBlockElementTests.swift
@@ -17,7 +17,11 @@ final class MarkdownBlockElementTests: XCTestCase {
         let (node, context) = parser.parse(input, root: root)
         XCTAssertTrue(context.errors.isEmpty)
         XCTAssertEqual(node.children.count, 1)
-        XCTAssertTrue(node.children.first is CodeBlockNode)
+        if let code = node.children.first as? CodeBlockNode {
+            XCTAssertEqual(code.language, "swift")
+        } else {
+            XCTFail("Expected CodeBlockNode")
+        }
     }
 
     func testHorizontalRule() {


### PR DESCRIPTION
## Summary
- extract language identifier when parsing fenced code blocks
- verify language value in `MarkdownBlockElementTests`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687d3df8db3c83229f89713e11eb0dad