### PR TITLE
Add at-sign token support

### DIFF
--- a/Sources/SwiftParser/Markdown/MarkdownTokenizer.swift
+++ b/Sources/SwiftParser/Markdown/MarkdownTokenizer.swift
@@ -66,6 +66,9 @@ public class MarkdownTokenizer: CodeTokenizer {
             
         case "^":
             addToken(.caret, text: "^", from: startIndex)
+
+        case "@":
+            addToken(.atSign, text: "@", from: startIndex)
             
         case "|":
             addToken(.pipe, text: "|", from: startIndex)
@@ -1174,7 +1177,7 @@ extension MarkdownTokenizer {
     /// Check if a character is a special character that should be tokenized separately
     private func isSpecialCharacter(_ char: Character) -> Bool {
         switch char {
-        case "#", "*", "_", "`", "-", "+", "=", "~", "^", "|", ":", ";", "!", "?", ".", ",", ">", "<", "&", "\\", "/", "\"", "'", "[", "]", "(", ")", "{", "}", "$":
+        case "#", "*", "_", "`", "-", "+", "=", "~", "^", "@", "|", ":", ";", "!", "?", ".", ",", ">", "<", "&", "\\", "/", "\"", "'", "[", "]", "(", ")", "{", "}", "$":
             return true
         case " ", "\t", "\n", "\r":
             return true

--- a/Sources/SwiftParser/Markdown/MarkdownTokens.swift
+++ b/Sources/SwiftParser/Markdown/MarkdownTokens.swift
@@ -11,6 +11,7 @@ public enum MarkdownTokenElement: String, CaseIterable, CodeTokenElement {
     case equals = "="
     case tilde = "~"
     case caret = "^"
+    case atSign = "@"
     case pipe = "|"
     case colon = ":"
     case semicolon = ";"
@@ -110,6 +111,10 @@ public class MarkdownToken: CodeToken {
     
     public static func tilde(at range: Range<String.Index>) -> MarkdownToken {
         return MarkdownToken(element: .tilde, text: "~", range: range)
+    }
+
+    public static func atSign(at range: Range<String.Index>) -> MarkdownToken {
+        return MarkdownToken(element: .atSign, text: "@", range: range)
     }
     
     public static func pipe(at range: Range<String.Index>) -> MarkdownToken {
@@ -261,7 +266,7 @@ extension MarkdownToken {
     /// Check if this token is a punctuation character
     public var isPunctuation: Bool {
         switch element {
-        case .exclamation, .question, .dot, .comma, .semicolon, .colon, .quote, .singleQuote:
+        case .exclamation, .question, .dot, .comma, .semicolon, .colon, .quote, .singleQuote, .atSign:
             return true
         default:
             return false

--- a/Tests/SwiftParserTests/Markdown/Tokenizer/MarkdownTokenizerBasicTests.swift
+++ b/Tests/SwiftParserTests/Markdown/Tokenizer/MarkdownTokenizerBasicTests.swift
@@ -445,9 +445,10 @@ final class MarkdownTokenizerBasicTests: XCTestCase {
         // Should tokenize each character individually and end with EOF
         XCTAssertEqual(tokens.count, 32) // 31 chars + EOF
         XCTAssertEqual(tokens.last?.element, .eof)
-        
+
         // Test some key characters are properly recognized
         XCTAssertEqual(tokens[0].element, .exclamation)
+        XCTAssertEqual(tokens[1].element, .atSign)
         XCTAssertEqual(tokens[2].element, .hash)
         XCTAssertEqual(tokens[5].element, .caret)
         XCTAssertEqual(tokens[6].element, .ampersand)


### PR DESCRIPTION
## Summary
- add `atSign` token type with a convenience builder
- tokenize `@` as its own token
- treat `@` as punctuation and special character
- check `@` tokenization in tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687e20c2168883229fa392a92a1ec4be