### PR TITLE
Refactor markdown tokenizer with builders

### DIFF
--- a/Sources/SwiftParser/LanguageExtensions.swift
+++ b/Sources/SwiftParser/LanguageExtensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension CodeLanguage {
+    @available(*, deprecated, renamed: "root")
+    public func root(of source: String) -> CodeNode<Node> {
+        return root()
+    }
+
+    @available(*, deprecated, renamed: "state")
+    public func state(of source: String) -> (any CodeConstructState<Node, Token>)? {
+        return state()
+    }
+}

--- a/Sources/SwiftParser/Markdown/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Markdown/MarkdownLanguage.swift
@@ -33,7 +33,13 @@ public class MarkdownLanguage: CodeLanguage {
     ) {
         self.tokenizer = tokenizer
         self.nodes = consumers
-        self.tokens = []
+        let single = MarkdownSingleCharacterTokenBuilder()
+        self.tokens = [
+            MarkdownWhitespaceTokenBuilder(),
+            single,
+            MarkdownNumberTokenBuilder(),
+            MarkdownTextTokenBuilder(singleCharacterMap: MarkdownSingleCharacterTokenBuilder.mapping)
+        ]
     }
     
     // MARK: - Language Protocol Implementation

--- a/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownNumberTokenBuilder.swift
+++ b/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownNumberTokenBuilder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public class MarkdownNumberTokenBuilder: CodeTokenBuilder {
+    public typealias Token = MarkdownTokenElement
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let char = context.source[context.consuming]
+        guard char.isNumber else { return false }
+        let start = context.consuming
+        var index = context.consuming
+        while index < context.source.endIndex && context.source[index].isNumber {
+            index = context.source.index(after: index)
+        }
+        context.consuming = index
+        let text = String(context.source[start..<index])
+        context.tokens.append(MarkdownToken.number(text, at: start..<index))
+        return true
+    }
+}

--- a/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownSingleCharacterTokenBuilder.swift
+++ b/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownSingleCharacterTokenBuilder.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+@preconcurrency
+public class MarkdownSingleCharacterTokenBuilder: CodeTokenBuilder {
+    public typealias Token = MarkdownTokenElement
+
+    @preconcurrency nonisolated(unsafe) static let mapping: [Character: MarkdownTokenElement] = [
+        "#": .hash,
+        "*": .asterisk,
+        "_": .underscore,
+        "-": .dash,
+        "+": .plus,
+        "=": .equals,
+        "~": .tilde,
+        "^": .caret,
+        "@": .atSign,
+        "|": .pipe,
+        ":": .colon,
+        ";": .semicolon,
+        "!": .exclamation,
+        "?": .question,
+        ".": .dot,
+        ",": .comma,
+        ">": .gt,
+        "<": .lt,
+        "&": .ampersand,
+        "\\": .backslash,
+        "/": .forwardSlash,
+        "\"": .quote,
+        "'": .singleQuote,
+        "[": .leftBracket,
+        "]": .rightBracket,
+        "(": .leftParen,
+        ")": .rightParen,
+        "{": .leftBrace,
+        "}": .rightBrace
+    ]
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let char = context.source[context.consuming]
+        guard let element = Self.mapping[char] else { return false }
+        let start = context.consuming
+        context.consuming = context.source.index(after: context.consuming)
+        let token = MarkdownToken(element: element, text: String(char), range: start..<context.consuming)
+        context.tokens.append(token)
+        return true
+    }
+}

--- a/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownTextTokenBuilder.swift
+++ b/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownTextTokenBuilder.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public class MarkdownTextTokenBuilder: CodeTokenBuilder {
+    public typealias Token = MarkdownTokenElement
+
+    private let boundaries: Set<Character>
+
+    public init(singleCharacterMap: [Character: MarkdownTokenElement]) {
+        var set = Set(singleCharacterMap.keys)
+        set.insert(" ")
+        set.insert("\t")
+        set.insert("\n")
+        set.insert("\r")
+        self.boundaries = set
+    }
+
+    public func build(from context: inout CodeTokenContext<MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let startChar = context.source[context.consuming]
+
+        if boundaries.contains(startChar) { return false }
+
+        if startChar.isNumber {
+            // treat as number if not surrounded by letters
+            let prevIsLetter: Bool
+            if context.consuming > context.source.startIndex {
+                let prev = context.source[context.source.index(before: context.consuming)]
+                prevIsLetter = prev.isLetter
+            } else {
+                prevIsLetter = false
+            }
+            let nextIdx = context.source.index(after: context.consuming)
+            let nextIsLetter = nextIdx < context.source.endIndex ? context.source[nextIdx].isLetter : false
+            if !prevIsLetter && !nextIsLetter {
+                return false
+            }
+        }
+
+        var index = context.consuming
+        while index < context.source.endIndex {
+            let c = context.source[index]
+            if boundaries.contains(c) { break }
+            index = context.source.index(after: index)
+        }
+        let start = context.consuming
+        context.consuming = index
+        let text = String(context.source[start..<index])
+        context.tokens.append(MarkdownToken.text(text, at: start..<index))
+        return true
+    }
+}

--- a/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownWhitespaceTokenBuilder.swift
+++ b/Sources/SwiftParser/Markdown/TokenBuilders/MarkdownWhitespaceTokenBuilder.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public class MarkdownWhitespaceTokenBuilder: CodeTokenBuilder {
+    public typealias Token = MarkdownTokenElement
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<MarkdownTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let char = context.source[context.consuming]
+
+        switch char {
+        case " ":
+            let start = context.consuming
+            context.consuming = context.source.index(after: context.consuming)
+            context.tokens.append(MarkdownToken.space(at: start..<context.consuming))
+            return true
+        case "\t":
+            let start = context.consuming
+            context.consuming = context.source.index(after: context.consuming)
+            context.tokens.append(MarkdownToken.tab(at: start..<context.consuming))
+            return true
+        case "\n":
+            let start = context.consuming
+            context.consuming = context.source.index(after: context.consuming)
+            context.tokens.append(MarkdownToken.newline(at: start..<context.consuming))
+            return true
+        case "\r":
+            let start = context.consuming
+            let next = context.source.index(after: context.consuming)
+            if next < context.source.endIndex && context.source[next] == "\n" {
+                context.consuming = context.source.index(after: next)
+                context.tokens.append(MarkdownToken.newline(at: start..<context.consuming))
+            } else {
+                context.consuming = next
+                let range = start..<context.consuming
+                context.tokens.append(MarkdownToken(element: .carriageReturn, text: "\r", range: range))
+            }
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/SwiftParserTests/Markdown/Tokenizer/MarkdownCodeTokenizerBasicTests.swift
+++ b/Tests/SwiftParserTests/Markdown/Tokenizer/MarkdownCodeTokenizerBasicTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import SwiftParser
+
+final class MarkdownCodeTokenizerBasicTests: XCTestCase {
+    func testHeadingTokenization() {
+        let language = MarkdownLanguage()
+        let tokenizer = CodeTokenizer(builders: language.tokens, state: language.state)
+        let (tokens, _) = tokenizer.tokenize("# Title")
+        XCTAssertEqual(tokens.count, 4)
+        XCTAssertEqual(tokens[0].element, .hash)
+        XCTAssertEqual(tokens[1].element, .space)
+        XCTAssertEqual(tokens[2].element, .text)
+        XCTAssertEqual(tokens[3].element, .eof)
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `MarkdownSingleCharacterTokenBuilder`, `MarkdownWhitespaceTokenBuilder`, `MarkdownNumberTokenBuilder`, and `MarkdownTextTokenBuilder`
- extend `MarkdownLanguage` to use these new builders with `CodeTokenizer`
- add helper extensions for deprecated `root(of:)` and `state(of:)`
- add basic test verifying new tokenizer
- adjust tokenizer test to match builder output
- add EOF token generation in `CodeTokenizer`

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_687f18ddc020832292667fd05c61bad9