### PR TITLE
Add SwiftUI renderer for Markdown

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
             name: "SwiftParser",
             targets: ["SwiftParser"]
         ),
+        .executable(
+            name: "SwiftParserShowCase",
+            targets: ["SwiftParserShowCase"]
+        ),
     ],
     dependencies: [
         // Add any external dependencies here
@@ -23,7 +27,7 @@ let package = Package(
             name: "SwiftParser",
             dependencies: []
         ),
-        .target(name: "SwiftParserShowCase",
+        .executableTarget(name: "SwiftParserShowCase",
             dependencies: ["SwiftParser"]
         ),
         .testTarget(

--- a/Sources/SwiftParserShowCase/App/ASTPrinter.swift
+++ b/Sources/SwiftParserShowCase/App/ASTPrinter.swift
@@ -1,0 +1,16 @@
+import SwiftParser
+
+struct ASTPrinter {
+    static func print(node: CodeNode<MarkdownNodeElement>, indent: Int = 0) -> String {
+        var lines: [String] = []
+        func recurse(_ node: CodeNode<MarkdownNodeElement>, _ depth: Int) {
+            let prefix = String(repeating: "  ", count: depth)
+            lines.append("\(prefix)\(node.element.rawValue)")
+            for child in node.children {
+                recurse(child, depth + 1)
+            }
+        }
+        recurse(node, indent)
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/SwiftParserShowCase/App/ContentView.swift
+++ b/Sources/SwiftParserShowCase/App/ContentView.swift
@@ -1,0 +1,211 @@
+#if canImport(SwiftUI) && !os(Linux)
+import SwiftUI
+import SwiftParser
+
+struct ContentView: View {
+    @State private var markdownText: String = ""
+    @State private var astText: String = ""
+    @State private var htmlText: String = ""
+    @State private var rootNode: MarkdownNodeBase?
+
+    var body: some View {
+        VStack {
+            TextEditor(text: $markdownText)
+                .border(Color.gray)
+                .frame(minHeight: 200)
+                .onChange(of: markdownText) { _ in
+                    updateOutputs()
+                }
+                .onAppear {
+                    updateOutputs()
+                }
+
+            TabView {
+                ScrollView {
+                    Text(astText)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                }
+                .tabItem { Text("Print AST") }
+
+                ScrollView {
+                    Text(htmlText)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                }
+                .tabItem { Text("Export HTML") }
+
+                ScrollView {
+                    if let rootNode {
+                        MarkdownView(root: rootNode)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                    }
+                }
+                .tabItem { Text("Render View") }
+            }
+        }
+        .padding()
+    }
+
+    private func updateOutputs() {
+        let language = MarkdownLanguage()
+        let parser = CodeParser(language: language)
+        let result = parser.parse(markdownText, language: language)
+        astText = ASTPrinter.print(node: result.root)
+        htmlText = HTMLExporter.export(node: result.root)
+        rootNode = result.root as? MarkdownNodeBase
+    }
+}
+
+// MARK: - Markdown Rendering
+@ViewBuilder
+private func MarkdownView(root: MarkdownNodeBase) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+        renderChildren(root.children())
+    }
+}
+
+@ViewBuilder
+private func renderChildren(_ nodes: [MarkdownNodeBase]) -> some View {
+    ForEach(nodes, id: \.id) { node in
+        render(node)
+    }
+}
+
+@ViewBuilder
+private func render(_ node: MarkdownNodeBase) -> some View {
+    switch node {
+    case let paragraph as ParagraphNode:
+        makeText(paragraph.children())
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 4)
+    case let header as HeaderNode:
+        makeText(header.children())
+            .font(.system(size: fontSize(for: header.level), weight: .bold))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 4)
+    case let code as CodeBlockNode:
+        ScrollView(.horizontal) {
+            Text(code.source)
+                .font(.system(.body, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(4)
+        }
+        .background(Color(.systemGray6))
+        .cornerRadius(4)
+        .padding(.bottom, 4)
+    case let blockquote as BlockquoteNode:
+        VStack(alignment: .leading, spacing: 4) {
+            renderChildren(blockquote.children())
+        }
+        .padding(.leading, 8)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .frame(width: 3)
+                .foregroundColor(Color.gray.opacity(0.6))
+        }
+        .padding(.bottom, 4)
+    case let list as OrderedListNode:
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(list.children().enumerated()), id: \.element.id) { idx, item in
+                if let li = item as? ListItemNode {
+                    HStack(alignment: .top) {
+                        Text("\(list.start + idx).")
+                        VStack(alignment: .leading, spacing: 4) {
+                            renderChildren(li.children())
+                        }
+                    }
+                } else {
+                    render(item)
+                }
+            }
+        }
+        .padding(.bottom, 4)
+    case let list as UnorderedListNode:
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(list.children(), id: \.id) { item in
+                if let li = item as? ListItemNode {
+                    HStack(alignment: .top) {
+                        Text("\u{2022}")
+                        VStack(alignment: .leading, spacing: 4) {
+                            renderChildren(li.children())
+                        }
+                    }
+                } else {
+                    render(item)
+                }
+            }
+        }
+        .padding(.bottom, 4)
+    case let image as ImageNode:
+        if let url = URL(string: image.url) {
+            if #available(iOS 15.0, macOS 12.0, *) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let img):
+                        img.resizable().scaledToFit()
+                    case .failure:
+                        Text(image.alt)
+                    case .empty:
+                        ProgressView()
+                    @unknown default:
+                        Text(image.alt)
+                    }
+                }
+            } else {
+                Text(image.alt)
+            }
+        } else {
+            Text(image.alt)
+        }
+        .padding(.bottom, 4)
+    default:
+        renderChildren(node.children())
+    }
+}
+
+private func fontSize(for level: Int) -> CGFloat {
+    switch level {
+    case 1: return 28
+    case 2: return 24
+    case 3: return 20
+    case 4: return 18
+    case 5: return 16
+    default: return 14
+    }
+}
+
+private func makeText(_ nodes: [MarkdownNodeBase]) -> Text {
+    nodes.reduce(Text("")) { result, node in
+        result + makeText(node)
+    }
+}
+
+private func makeText(_ node: MarkdownNodeBase) -> Text {
+    switch node {
+    case let text as TextNode:
+        return Text(text.content)
+    case let strong as StrongNode:
+        return makeText(strong.children()).bold()
+    case let emphasis as EmphasisNode:
+        return makeText(emphasis.children()).italic()
+    case let strike as StrikeNode:
+        return makeText(strike.children()).strikethrough()
+    case let code as InlineCodeNode:
+        return Text(code.code)
+            .font(.system(.body, design: .monospaced))
+            .background(Color(.systemGray5))
+    case let link as LinkNode:
+        return makeText(link.children())
+            .foregroundColor(.blue)
+    case is LineBreakNode:
+        return Text("\n")
+    default:
+        return node.children().reduce(Text("")) { result, child in
+            result + makeText(child)
+        }
+    }
+}
+
+#endif

--- a/Sources/SwiftParserShowCase/App/HTMLExporter.swift
+++ b/Sources/SwiftParserShowCase/App/HTMLExporter.swift
@@ -1,0 +1,76 @@
+import SwiftParser
+
+struct HTMLExporter {
+    static func export(node: CodeNode<MarkdownNodeElement>) -> String {
+        guard let markdownNode = node as? MarkdownNodeBase else {
+            return node.children.map { export(node: $0) }.joined()
+        }
+        return render(markdownNode)
+    }
+
+    private static func render(_ node: MarkdownNodeBase) -> String {
+        switch node {
+        case let document as DocumentNode:
+            return document.children().map { render($0) }.joined(separator: "\n")
+        case let header as HeaderNode:
+            let body = header.children().map { render($0) }.joined()
+            return "<h\(header.level)>\(body)</h\(header.level)>"
+        case is ParagraphNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<p>\(body)</p>"
+        case is EmphasisNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<em>\(body)</em>"
+        case is StrongNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<strong>\(body)</strong>"
+        case is StrikeNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<del>\(body)</del>"
+        case let text as TextNode:
+            return escape(text.content)
+        case let code as InlineCodeNode:
+            return "<code>\(escape(code.code))</code>"
+        case let block as CodeBlockNode:
+            let lang = block.language.map { " class=\"language-\($0)\"" } ?? ""
+            return "<pre><code\(lang)>\(escape(block.source))</code></pre>"
+        case is BlockquoteNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<blockquote>\(body)</blockquote>"
+        case let list as OrderedListNode:
+            let body = list.children().map { render($0) }.joined()
+            return "<ol start=\(list.start)>\(body)</ol>"
+        case is UnorderedListNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<ul>\(body)</ul>"
+        case is ListItemNode:
+            let body = node.children().map { render($0) }.joined()
+            return "<li>\(body)</li>"
+        case is ThematicBreakNode:
+            return "<hr/>"
+        case let link as LinkNode:
+            let body = link.children().map { render($0) }.joined()
+            return "<a href=\"\(escape(link.url))\">\(body)</a>"
+        case let image as ImageNode:
+            return "<img src=\"\(escape(image.url))\" alt=\"\(escape(image.alt))\"/>"
+        case let html as HTMLNode:
+            return html.content
+        case let htmlBlock as HTMLBlockNode:
+            return "<\(htmlBlock.name)>\(htmlBlock.content)</\(htmlBlock.name)>"
+        case is LineBreakNode:
+            return "<br/>"
+        default:
+            return node.children().map { render($0) }.joined()
+        }
+    }
+
+    private static func escape(_ text: String) -> String {
+        var escaped = text
+        escaped = escaped.replacingOccurrences(of: "&", with: "&amp;")
+        escaped = escaped.replacingOccurrences(of: "<", with: "&lt;")
+        escaped = escaped.replacingOccurrences(of: ">", with: "&gt;")
+        escaped = escaped.replacingOccurrences(of: "\"", with: "&quot;")
+        escaped = escaped.replacingOccurrences(of: "'", with: "&#39;")
+        return escaped
+    }
+}

--- a/Sources/SwiftParserShowCase/App/SwiftParserShowCaseApp.swift
+++ b/Sources/SwiftParserShowCase/App/SwiftParserShowCaseApp.swift
@@ -1,0 +1,12 @@
+#if canImport(SwiftUI) && !os(Linux)
+import SwiftUI
+
+@main
+struct SwiftParserShowCaseApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+#endif

--- a/Sources/SwiftParserShowCase/main.swift
+++ b/Sources/SwiftParserShowCase/main.swift
@@ -1,0 +1,3 @@
+#if os(Linux)
+print("SwiftParserShowCase is not available on Linux.")
+#endif


### PR DESCRIPTION
## Summary
- use a custom SwiftUI view to render Markdown instead of `AttributedString`
- keep the AST and HTML exports

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_68811e1fd2e083228f0bbf2f4b0debe1