### PR TITLE
refactor: modularize inline markdown parsing

### DIFF
--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownAdmonitionBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownAdmonitionBuilder.swift
@@ -35,9 +35,16 @@ public class MarkdownAdmonitionBuilder: CodeNodeBuilder {
            let sp = context.tokens[idx] as? MarkdownToken,
            sp.element == .space { idx += 1 }
         context.consuming = idx
-        let children = MarkdownInlineParser.parseInline(&context)
         let node = AdmonitionNode(kind: kind)
-        for c in children { node.append(c) }
+        var inlineCtx = CodeConstructContext(
+            current: node,
+            tokens: context.tokens,
+            consuming: context.consuming,
+            state: context.state
+        )
+        let inlineBuilder = MarkdownInlineBuilder()
+        _ = inlineBuilder.build(from: &inlineCtx)
+        context.consuming = inlineCtx.consuming
         context.current.append(node)
         if context.consuming < context.tokens.count,
            let nl2 = context.tokens[context.consuming] as? MarkdownToken,

--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownBlockquoteBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownBlockquoteBuilder.swift
@@ -16,10 +16,16 @@ public class MarkdownBlockquoteBuilder: CodeNodeBuilder {
            space.element == .space {
             context.consuming += 1
         }
-        // Parse inline content until a newline or EOF inside the blockquote
-        let children = MarkdownInlineParser.parseInline(&context)
         let node = BlockquoteNode()
-        for child in children { node.append(child) }
+        var inlineCtx = CodeConstructContext(
+            current: node,
+            tokens: context.tokens,
+            consuming: context.consuming,
+            state: context.state
+        )
+        let inlineBuilder = MarkdownInlineBuilder()
+        _ = inlineBuilder.build(from: &inlineCtx)
+        context.consuming = inlineCtx.consuming
         context.current.append(node)
         if context.consuming < context.tokens.count,
            let nl = context.tokens[context.consuming] as? MarkdownToken,

--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownDefinitionListBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownDefinitionListBuilder.swift
@@ -51,16 +51,17 @@ public class MarkdownDefinitionListBuilder: CodeNodeBuilder {
             context.consuming += 1
         }
 
-        var termContext = CodeConstructContext(current: DocumentNode(), tokens: termTokens)
-        let termChildren = MarkdownInlineParser.parseInline(&termContext)
-        var defContext = CodeConstructContext(current: DocumentNode(), tokens: defTokens)
-        let defChildren = MarkdownInlineParser.parseInline(&defContext)
+        let termNode = DefinitionTermNode()
+        var termContext = CodeConstructContext(current: termNode, tokens: termTokens, state: context.state)
+        let inlineBuilder = MarkdownInlineBuilder(stopAt: [])
+        _ = inlineBuilder.build(from: &termContext)
+
+        let descNode = DefinitionDescriptionNode()
+        var defContext = CodeConstructContext(current: descNode, tokens: defTokens, state: context.state)
+        let inlineBuilder2 = MarkdownInlineBuilder(stopAt: [])
+        _ = inlineBuilder2.build(from: &defContext)
 
         let item = DefinitionItemNode()
-        let termNode = DefinitionTermNode()
-        for c in termChildren { termNode.append(c) }
-        let descNode = DefinitionDescriptionNode()
-        for c in defChildren { descNode.append(c) }
         item.append(termNode)
         item.append(descNode)
 

--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownHeadingBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownHeadingBuilder.swift
@@ -26,10 +26,16 @@ public class MarkdownHeadingBuilder: CodeNodeBuilder {
         idx += 1
 
         context.consuming = idx
-        // Parse inline content until a newline or EOF
-        let children = MarkdownInlineParser.parseInline(&context)
         let node = HeaderNode(level: level)
-        for child in children { node.append(child) }
+        var inlineCtx = CodeConstructContext(
+            current: node,
+            tokens: context.tokens,
+            consuming: context.consuming,
+            state: context.state
+        )
+        let inlineBuilder = MarkdownInlineBuilder()
+        _ = inlineBuilder.build(from: &inlineCtx)
+        context.consuming = inlineCtx.consuming
         context.current.append(node)
 
         if context.consuming < context.tokens.count,

--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownListBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownListBuilder.swift
@@ -86,8 +86,15 @@ public class MarkdownListBuilder: CodeNodeBuilder {
         } else {
             item = ListItemNode(marker: markerText)
         }
-        let children = MarkdownInlineParser.parseInline(&context)
-        for child in children { item.append(child) }
+        var inlineCtx = CodeConstructContext(
+            current: item,
+            tokens: context.tokens,
+            consuming: context.consuming,
+            state: context.state
+        )
+        let inlineBuilder = MarkdownInlineBuilder()
+        _ = inlineBuilder.build(from: &inlineCtx)
+        context.consuming = inlineCtx.consuming
         listNode.append(item)
 
         if context.consuming < context.tokens.count,

--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownParagraphBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownParagraphBuilder.swift
@@ -11,9 +11,15 @@ public class MarkdownParagraphBuilder: CodeNodeBuilder {
               token.element != .eof else { return false }
 
         let node = ParagraphNode(range: token.range)
-        // Stop parsing at either a newline or EOF to avoid leftover empty nodes
-        let children = MarkdownInlineParser.parseInline(&context)
-        for child in children { node.append(child) }
+        var inlineCtx = CodeConstructContext(
+            current: node,
+            tokens: context.tokens,
+            consuming: context.consuming,
+            state: context.state
+        )
+        let inlineBuilder = MarkdownInlineBuilder()
+        _ = inlineBuilder.build(from: &inlineCtx)
+        context.consuming = inlineCtx.consuming
         context.current.append(node)
 
         if context.consuming < context.tokens.count,

--- a/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownTableBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Markdown/Nodes/MarkdownTableBuilder.swift
@@ -42,8 +42,8 @@ public class MarkdownTableBuilder: CodeNodeBuilder {
             if tok.element == .pipe {
                 let cell = TableCellNode(range: start.range)
                 var subCtx = CodeConstructContext(current: cell, tokens: cellTokens, state: context.state)
-                let children = MarkdownInlineParser.parseInline(&subCtx, stopAt: [])
-                for child in children { cell.append(child) }
+                let inlineBuilder = MarkdownInlineBuilder(stopAt: [])
+                _ = inlineBuilder.build(from: &subCtx)
                 row.append(cell)
                 cellTokens.removeAll()
             } else {


### PR DESCRIPTION
## Summary
- refactor MarkdownInlineParser to use composite builder pattern
- add dedicated builders for emphasis, links, images, HTML, code, formulas, autolinks, and text

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6894368d613c8322b0901f0d15d833e6